### PR TITLE
- Added PGADMIN_PORT env variable

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
           - name: PGADMIN_ENABLE_TLS
             value: {{ .Values.pgadmin.tls | quote }}
          {{- end }}
+          - name: PGADMIN_PORT
+            value: {{ .Values.service.port }}
           ports:
           - name: http
             containerPort: 80


### PR DESCRIPTION
Added PGADMIN_PORT as environment variable. This solves "ValueError: invalid literal for int() with base 10" problem